### PR TITLE
feat(10036B): Implement HTTP-only cookie JWT with 30-min expiration

### DIFF
--- a/src/main/java/com/rdp/config/SecurityConfig.java
+++ b/src/main/java/com/rdp/config/SecurityConfig.java
@@ -18,76 +18,78 @@ import java.util.List;
 
 @Configuration
 public class SecurityConfig {
-	@Autowired private JwtAuthFilter jwtAuthFilter;
+    @Autowired private JwtAuthFilter jwtAuthFilter;
 
-	@Bean
-	public PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(); }
+    @Bean
+    public PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(); }
 
-	@Bean
-	public UserDetailsService userDetailsService(CustomUserDetailsService customService) { return customService; }
+    @Bean
+    public UserDetailsService userDetailsService(CustomUserDetailsService customService) { return customService; }
 
-	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http
-				.csrf(csrf -> csrf.disable())
-				.cors(cors -> cors.configurationSource(req -> {
-					var c = new CorsConfiguration();
-					c.setAllowedOrigins(List.of("http://localhost:3000", "http://192.168.1.103:3000"));
-					c.setAllowedMethods(List.of("GET","POST","PUT","DELETE","PATCH","OPTIONS"));
-					c.setAllowedHeaders(List.of("Authorization","Content-Type"));
-					return c;
-				}))
-				.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-				.authorizeHttpRequests(auth -> auth
-						.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-						.requestMatchers("/api/auth/login").permitAll()
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .cors(cors -> cors.configurationSource(req -> {
+                var c = new CorsConfiguration();
+                c.setAllowedOrigins(List.of("http://localhost:3000", "http://192.168.1.103:3000"));
+                c.setAllowedMethods(List.of("GET","POST","PUT","DELETE","PATCH","OPTIONS"));
+                c.setAllowedHeaders(List.of("Authorization","Content-Type"));
+                c.setAllowCredentials(true);  // IMPORTANT: Allow cookies to be sent
+                return c;
+            }))
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .requestMatchers("/api/auth/login").permitAll()
+                .requestMatchers("/api/auth/logout").permitAll()
+                .requestMatchers("/api/auth/validate").permitAll()
 
-                        // categories
-                        .requestMatchers(HttpMethod.GET, "/api/categories/**")
-                        .hasAnyRole("ADMIN","PHARMACIST","MANAGER")
-                        .requestMatchers("/api/categories/**")
-                        .hasRole("ADMIN") // POST/PUT/DELETE
+                // categories
+                .requestMatchers(HttpMethod.GET, "/api/categories/**")
+                .hasAnyRole("ADMIN","PHARMACIST","MANAGER")
+                .requestMatchers("/api/categories/**")
+                .hasRole("ADMIN") // POST/PUT/DELETE
 
-						// Suppliers
-						.requestMatchers(org.springframework.http.HttpMethod.GET, "/api/suppliers/**")
-						.hasAnyRole("ADMIN","PHARMACIST","MANAGER")
-						.requestMatchers("/api/suppliers/**")
-						.hasRole("ADMIN") // POST/PUT/DELETE
+                // Suppliers
+                .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/suppliers/**")
+                .hasAnyRole("ADMIN","PHARMACIST","MANAGER")
+                .requestMatchers("/api/suppliers/**")
+                .hasRole("ADMIN") // POST/PUT/DELETE
 
-                        // Products
-                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/products/**")
-                        .hasAnyRole("ADMIN","PHARMACIST","MANAGER")
-                        .requestMatchers("/api/products/**")
-                        .hasRole("ADMIN")
-						.requestMatchers(HttpMethod.POST, "/api/products/bulk").hasRole("ADMIN")// POST/PUT/DELETE
+                // Products
+                .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/products/**")
+                .hasAnyRole("ADMIN","PHARMACIST","MANAGER")
+                .requestMatchers("/api/products/**")
+                .hasRole("ADMIN")
+                .requestMatchers(HttpMethod.POST, "/api/products/bulk").hasRole("ADMIN")// POST/PUT/DELETE
 
-						// Customers
-						.requestMatchers(HttpMethod.GET, "/api/customers/**")
-						.hasAnyRole("ADMIN","PHARMACIST","MANAGER")
-						.requestMatchers("/api/customers/**")
-						.hasRole("ADMIN") // POST/PUT/DELETE
+                // Customers
+                .requestMatchers(HttpMethod.GET, "/api/customers/**")
+                .hasAnyRole("ADMIN","PHARMACIST","MANAGER")
+                .requestMatchers("/api/customers/**")
+                .hasRole("ADMIN") // POST/PUT/DELETE
 
-						// purchase order
-						.requestMatchers(HttpMethod.GET,   "/api/purchase-orders/**").hasAnyRole("ADMIN","MANAGER","PHARMACIST")
-						.requestMatchers(HttpMethod.POST,  "/api/purchase-orders/**").hasRole("ADMIN")
-						.requestMatchers(HttpMethod.DELETE,"/api/purchase-orders/**").hasRole("ADMIN")
-						.requestMatchers(HttpMethod.PATCH,"/api/purchase-orders/**").hasRole("ADMIN")
+                // purchase order
+                .requestMatchers(HttpMethod.GET,   "/api/purchase-orders/**").hasAnyRole("ADMIN","MANAGER","PHARMACIST")
+                .requestMatchers(HttpMethod.POST,  "/api/purchase-orders/**").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.DELETE,"/api/purchase-orders/**").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.PATCH,"/api/purchase-orders/**").hasRole("ADMIN")
 
+                // User self-profile update (allow all authenticated users)
+                .requestMatchers(HttpMethod.PUT, "/api/users/me").authenticated()
+                .requestMatchers(HttpMethod.GET, "/api/users/me").authenticated()
 
-						// User self-profile update (allow all authenticated users)
-						.requestMatchers(HttpMethod.PUT, "/api/users/me").authenticated()
-						.requestMatchers(HttpMethod.GET, "/api/users/me").authenticated()
+                // other domains
+                .requestMatchers("/api/grn/approve").hasRole("ADMIN")
+                .requestMatchers("/api/reports/**").hasAnyRole("ADMIN","MANAGER")
+                .requestMatchers("/api/sales/**").hasAnyRole("ADMIN","MANAGER","PHARMACIST")
+                .anyRequest().authenticated()
+            )
+            .formLogin(form -> form.disable())
+            .httpBasic(basic -> basic.disable());
 
-						// other domains
-						.requestMatchers("/api/grn/approve").hasRole("ADMIN")
-						.requestMatchers("/api/reports/**").hasAnyRole("ADMIN","MANAGER")
-						.requestMatchers("/api/sales/**").hasAnyRole("ADMIN","MANAGER","PHARMACIST")
-						.anyRequest().authenticated()
-                )
-				.formLogin(form -> form.disable())
-				.httpBasic(basic -> basic.disable());
-
-		http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
-		return http.build();
-	}
+        http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
 }

--- a/src/main/java/com/rdp/controller/AuthController.java
+++ b/src/main/java/com/rdp/controller/AuthController.java
@@ -3,9 +3,14 @@ package com.rdp.controller;
 import com.rdp.model.User;
 import com.rdp.repository.UserRepository;
 import com.rdp.security.JwtUtil;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.Map;
@@ -17,6 +22,8 @@ public class AuthController {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    
+    public static final String JWT_COOKIE_NAME = "jwt_token";
 
     public AuthController(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
         this.userRepository = userRepository;
@@ -25,7 +32,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public Map<String, Object> login(@RequestBody Map<String, String> payload) {
+    public ResponseEntity<Map<String, Object>> login(@RequestBody Map<String, String> payload, HttpServletResponse response) {
         String username = payload.get("username");
         String password = payload.get("password");
         User user = userRepository.findByUsername(username).orElse(null);
@@ -34,10 +41,106 @@ public class AuthController {
         }
         List<String> roles = user.getRoles().stream().map(r -> r.getRoleName()).collect(Collectors.toList());
         String token = jwtUtil.generateToken(username, roles);
-        return Map.of(
-            "token", token,
+        
+        // Set JWT in HTTP-only cookie
+        ResponseCookie cookie = ResponseCookie.from(JWT_COOKIE_NAME, token)
+            .httpOnly(true)                    // Cannot be accessed by JavaScript
+            .secure(false)                     // Set to true in production (HTTPS only)
+            .path("/")                         // Available for all paths
+            .maxAge(jwtUtil.getJwtExpirationMs() / 1000)  // 30 minutes in seconds
+            .sameSite("Lax")                   // CSRF protection
+            .build();
+        
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        
+        // Return user info (but NOT the token - it's in the cookie)
+        return ResponseEntity.ok(Map.of(
             "username", username,
-            "roles", roles // send as real array
-        );
+            "roles", roles,
+            "message", "Login successful"
+        ));
+    }
+    
+    @PostMapping("/logout")
+    public ResponseEntity<Map<String, String>> logout(HttpServletResponse response) {
+        // Clear the JWT cookie by setting it to empty with immediate expiration
+        ResponseCookie cookie = ResponseCookie.from(JWT_COOKIE_NAME, "")
+            .httpOnly(true)
+            .secure(false)                     // Set to true in production
+            .path("/")
+            .maxAge(0)                         // Immediate expiration
+            .sameSite("Lax")
+            .build();
+        
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        
+        return ResponseEntity.ok(Map.of("message", "Logout successful"));
+    }
+    
+    @GetMapping("/validate")
+    public ResponseEntity<Map<String, Object>> validateToken(HttpServletRequest request) {
+        // This endpoint validates the current token from cookie
+        String token = extractTokenFromCookie(request);
+        if (token == null || !jwtUtil.validateJwtToken(token)) {
+            return ResponseEntity.status(401).body(Map.of(
+                "valid", false,
+                "message", "Invalid or expired token"
+            ));
+        }
+        
+        String username = jwtUtil.getUsernameFromToken(token);
+        List<String> roles = jwtUtil.getRolesFromToken(token);
+        
+        return ResponseEntity.ok(Map.of(
+            "valid", true,
+            "username", username,
+            "roles", roles
+        ));
+    }
+    
+    @PostMapping("/refresh")
+    public ResponseEntity<Map<String, Object>> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        // Refresh the token if the current one is still valid
+        String token = extractTokenFromCookie(request);
+        if (token == null || !jwtUtil.validateJwtToken(token)) {
+            return ResponseEntity.status(401).body(Map.of(
+                "success", false,
+                "message", "Invalid or expired token"
+            ));
+        }
+        
+        String username = jwtUtil.getUsernameFromToken(token);
+        List<String> roles = jwtUtil.getRolesFromToken(token);
+        
+        // Generate new token
+        String newToken = jwtUtil.generateToken(username, roles);
+        
+        // Set new JWT cookie
+        ResponseCookie cookie = ResponseCookie.from(JWT_COOKIE_NAME, newToken)
+            .httpOnly(true)
+            .secure(false)
+            .path("/")
+            .maxAge(jwtUtil.getJwtExpirationMs() / 1000)
+            .sameSite("Lax")
+            .build();
+        
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        
+        return ResponseEntity.ok(Map.of(
+            "success", true,
+            "message", "Token refreshed"
+        ));
+    }
+    
+    private String extractTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (JWT_COOKIE_NAME.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/rdp/security/JwtAuthFilter.java
+++ b/src/main/java/com/rdp/security/JwtAuthFilter.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -20,6 +21,8 @@ import java.util.stream.Collectors;
 @Component
 public class JwtAuthFilter extends OncePerRequestFilter {
     private static final Logger log = LoggerFactory.getLogger(JwtAuthFilter.class);
+    private static final String JWT_COOKIE_NAME = "jwt_token";
+    
     @Autowired
     private JwtUtil jwtUtil;
 
@@ -29,14 +32,28 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
             throws ServletException, IOException {
 
-        String header = request.getHeader("Authorization");
         String token = null;
 
-        if (header != null && header.startsWith("Bearer ")) {
-            token = header.substring(7);
+        // First, try to get token from HTTP-only cookie
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (JWT_COOKIE_NAME.equals(cookie.getName())) {
+                    token = cookie.getValue();
+                    break;
+                }
+            }
+        }
+        
+        // Fallback: try Authorization header (for backward compatibility)
+        if (token == null) {
+            String header = request.getHeader("Authorization");
+            if (header != null && header.startsWith("Bearer ")) {
+                token = header.substring(7);
+            }
         }
 
-        if (token != null) {
+        if (token != null && !token.isEmpty()) {
             if (jwtUtil.validateJwtToken(token)) {
                 String username = jwtUtil.getUsernameFromToken(token);
                 List<String> roles = jwtUtil.getRolesFromToken(token);

--- a/src/main/java/com/rdp/security/JwtUtil.java
+++ b/src/main/java/com/rdp/security/JwtUtil.java
@@ -10,8 +10,11 @@ import java.nio.charset.StandardCharsets;
 
 @Component
 public class JwtUtil {
-    private final String jwtSecret = "yourSuperLongSecretKeyThatIsAtLeast64CharactersLongForHS512Algorithm1234567890"; // 32+ chars for HS512
-    private final long jwtExpirationMs = 86400000; // 1 day
+    private final String jwtSecret = "yourSuperLongSecretKeyThatIsAtLeast64CharactersLongForHS512Algorithm1234567890";
+    
+    // Token expiration: 30 minutes (matches frontend inactivity timeout)
+    private final long jwtExpirationMs = 30 * 60 * 1000; // 30 minutes
+    
     private final SecretKey key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
 
     public String generateToken(String username, List<String> roles) {
@@ -45,5 +48,9 @@ public class JwtUtil {
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
+    }
+    
+    public long getJwtExpirationMs() {
+        return jwtExpirationMs;
     }
 }


### PR DESCRIPTION
- JWT token set in HTTP-only cookie (secure from XSS attacks)
- Token expiration reduced to 30 minutes (matches frontend inactivity)
- Added /api/auth/logout endpoint to clear cookie
- Added /api/auth/validate endpoint to verify token
- Added /api/auth/refresh endpoint to extend session
- JwtAuthFilter reads from cookie (with Authorization header fallback)
- CORS configured with allowCredentials for cookie support
- SameSite=Lax for CSRF protection